### PR TITLE
ARView.render needs to be called before the pose acquisition

### DIFF
--- a/examples/boilerplate.html
+++ b/examples/boilerplate.html
@@ -142,6 +142,10 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Render the device's camera stream on screen first of all.
+  // It allows to get the right pose synchronized with the right frame.
+  arView.render();
+
   // Update our camera projection matrix in the event that
   // the near or far planes have updated
   camera.updateProjectionMatrix();
@@ -155,9 +159,6 @@ function update() {
   if (!boxesAdded && !camera.position.y) {
     addBoxes();
   }
-
-  // Render the device's camera stream on screen
-  arView.render();
 
   // Render our three.js virtual scene
   renderer.clearDepth();

--- a/examples/reticle.html
+++ b/examples/reticle.html
@@ -152,6 +152,10 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Render the device's camera stream on screen first of all.
+  // It allows to get the right pose synchronized with the right frame.
+  arView.render();
+
   // Update our camera projection matrix in the event that
   // the near or far planes have updated
   camera.updateProjectionMatrix();
@@ -163,9 +167,6 @@ function update() {
 
   // Update our perspective camera's positioning
   vrControls.update();
-
-  // Render the device's camera stream on screen
-  arView.render();
 
   // Render our three.js virtual scene
   renderer.clearDepth();

--- a/examples/spawn-at-camera.html
+++ b/examples/spawn-at-camera.html
@@ -178,6 +178,10 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Render the device's camera stream on screen first of all.
+  // It allows to get the right pose synchronized with the right frame.
+  arView.render();
+
   // Update our camera projection matrix in the event that
   // the near or far planes have updated
   camera.updateProjectionMatrix();
@@ -188,9 +192,6 @@ function update() {
 
   // Update our perspective camera's positioning
   vrControls.update();
-
-  // Render the device's camera stream on screen
-  arView.render();
 
   // Render our three.js virtual scene
   renderer.clearDepth();

--- a/examples/spawn-at-surface.html
+++ b/examples/spawn-at-surface.html
@@ -183,15 +183,16 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Render the device's camera stream on screen first of all.
+  // It allows to get the right pose synchronized with the right frame.
+  arView.render();
+
   // Update our camera projection matrix in the event that
   // the near or far planes have updated
   camera.updateProjectionMatrix();
 
   // Update our perspective camera's positioning
   vrControls.update();
-
-  // Render the device's camera stream on screen
-  arView.render();
 
   // Render our three.js virtual scene
   renderer.clearDepth();


### PR DESCRIPTION
This improves the frame-pose synchronization.