### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ If you're using a build tool, like [browserify] or [webpack], install it via [np
 $ npm install --save three three.ar.js
 ```
 
+### CDN
+
+```
+<script href="https://cdn.jsdelivr.net/npm/three.ar.js@0.1.4/dist/three.ar.js"></script>
+```
+
 ## Using
 
 If you are including three.ar.js via script tag, the additional three.ar.js features are appended to the `THREE` namespace, for example:


### PR DESCRIPTION
I added a jsDelivr link to your Readme so it is easier to use, [jsDelivr](https://www.jsdelivr.com/) is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage.