### PR TITLE
Use three.js as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ $ npm install --save three three.ar.js
 
 ## Using
 
+Accessing three.ar.js depends on the environment you're working in. Below are examples of importing
+the code via script tag, as well as a module bundler like [browserify] or [webpack].
+
+To view the additional APIs implemented by [WebARonARKit] and [WebARonARCore], view the [WebVR Extension for AR] document.
+
+To view the additional APIs implemented by [WebARonARKit] and [WebARonARCore], view the [WebVR Extension for AR] document.
+
+For more examples, see the [examples/](examples/) directory.
+
+### Script
+
 If you are including three.ar.js via script tag, the additional three.ar.js features are appended to the `THREE` namespace, for example:
 
 ```js
@@ -72,9 +83,23 @@ function update() {
 }
 ```
 
-To view the additional APIs implemented by [WebARonARKit] and [WebARonARCore], view the [WebVR Extension for AR] document.
+### Modules
 
-For more examples, see the [examples/](examples/) directory.
+If you're in a [browserify] or [webpack] like environment, three.ar.js uses [three.js]
+as a peer dependency. This means you can import both packages separately.
+
+```js
+import { Scene, WebGLRenderer } from 'three';
+import { ARUtils, ARPerspectiveCamera, ARView } from 'three.ar.js';
+
+async function init() {
+  const display = await ARUtils.getARDisplay();
+  const renderer = new WebGLRenderer({ alpha: true });
+  const arView = new ARView(display, renderer);
+
+  // And so forth...
+}
+```
 
 ## Contributing
 
@@ -108,7 +133,7 @@ For testing functionality, go through the examples with your changes and ensure 
 
 ## Examples
 
-Examples of three.ar.js are in the `/examples` directory. 
+Examples of three.ar.js are in the `/examples` directory.
 
 A [list of examples](https://developers.google.com/ar/develop/web/getting-started#examples) that are compatible with [WebARonARKit] and [WebARonARCore] is also available at [developers.google.com].
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "glslify-loader": "^1.0.2",
     "raw-loader": "^0.5.1",
     "uglifyjs-webpack-plugin": "1.0.0-beta.2",
-    "webpack": "^2.6.1",
-    "webpack-dev-server": "^2.5.0"
+    "webpack": "^3.6.0",
+    "webpack-dev-server": "^2.9.1"
   },
   "keywords": [
     "webar",
@@ -35,5 +35,8 @@
     "webaronarkit",
     "augmented reality"
   ],
+  "peerDependencies": {
+    "three": "*"
+  },
   "repository": "https://github.com/google-ar/three.ar.js"
 }

--- a/src/ARDebug.js
+++ b/src/ARDebug.js
@@ -518,5 +518,4 @@ class ARDebugPlanesRow extends ARDebugRow {
   }
 }
 
-THREE.ARDebug = ARDebug;
 export default ARDebug;

--- a/src/ARPerspectiveCamera.js
+++ b/src/ARPerspectiveCamera.js
@@ -13,16 +13,18 @@
  * limitations under the License.
  */
 
+import { PerspectiveCamera } from 'three';
+
 // Reuse the frame data for getting the projection matrix
 let frameData;
 
 /**
- * Class extending a THREE.PerspectiveCamera, attempting
+ * Class extending a PerspectiveCamera, attempting
  * to use the projection matrix provided from an AR-enabled
  * VRDisplay. If no AR-enabled VRDisplay found, uses provided
  * parameters.
  */
-class ARPerspectiveCamera extends THREE.PerspectiveCamera {
+class ARPerspectiveCamera extends PerspectiveCamera {
   /**
    * @param {VRDisplay} vrDisplay
    * @param {number} fov
@@ -77,5 +79,4 @@ class ARPerspectiveCamera extends THREE.PerspectiveCamera {
   }
 }
 
-THREE.ARPerspectiveCamera = ARPerspectiveCamera;
 export default ARPerspectiveCamera;

--- a/src/ARPlanes.js
+++ b/src/ARPlanes.js
@@ -13,24 +13,30 @@
  * limitations under the License.
  */
 
+import {
+  MirroredRepeatWrapping, DoubleSide,
+  Color, Object3D, RawShaderMaterial, TextureLoader,
+  Geometry, Vector3, Face3,
+} from 'three';
+
 import { getRandomPaletteColor } from './ARUtils';
 import vertexShader from './shaders/arplanes.vert';
 import fragmentShader from './shaders/arplanes.frag';
 import textureURL from './textures/plane.png';
 
-const texture = new THREE.TextureLoader().load(textureURL);
-texture.wrapS = THREE.MirroredRepeatWrapping;
-texture.wrapT = THREE.MirroredRepeatWrapping;
+const texture = new TextureLoader().load(textureURL);
+texture.wrapS = MirroredRepeatWrapping;
+texture.wrapT = MirroredRepeatWrapping;
 
-const DEFAULT_MATERIAL = new THREE.RawShaderMaterial({
-  side: THREE.DoubleSide,
+const DEFAULT_MATERIAL = new RawShaderMaterial({
+  side: DoubleSide,
   transparent: true,
   uniforms: {
     uTexture: {
       value: texture,
     },
     uColor: {
-      value: new THREE.Color(0x000000),
+      value: new Color(0x000000),
     },
   },
   vertexShader,
@@ -41,7 +47,7 @@ const DEFAULT_MATERIAL = new THREE.RawShaderMaterial({
  * The ARDebugRow subclass for displaying planes information
  * by wrapping polling getPlanes, and rendering.
  */
-class ARPlanes extends THREE.Object3D {
+class ARPlanes extends Object3D {
   /**
    * @param {VRDisplay} vrDisplay
    */
@@ -89,7 +95,7 @@ class ARPlanes extends THREE.Object3D {
       }
 
       const id = anchor.identifier;
-      const planeObj = new THREE.Object3D();
+      const planeObj = new Object3D();
       const mm = anchor.modelMatrix;
       planeObj.matrixAutoUpdate = false;
       planeObj.matrix.set(
@@ -101,11 +107,11 @@ class ARPlanes extends THREE.Object3D {
       this.add(planeObj);
       this.planes.push(planeObj);
 
-      const geo = new THREE.Geometry();
+      const geo = new Geometry();
       // generate vertices
       for (let pt = 0; pt < anchor.vertices.length / 3; pt++) {
         geo.vertices.push(
-          new THREE.Vector3(anchor.vertices[pt * 3],
+          new Vector3(anchor.vertices[pt * 3],
                             anchor.vertices[(pt * 3) + 1],
                             anchor.vertices[(pt * 3) + 2]));
       }
@@ -113,7 +119,7 @@ class ARPlanes extends THREE.Object3D {
       // generate faces
       for (let face = 0; face < geo.vertices.length - 2; face++) {
         // this makes a triangle fan, from the first +Y point around
-        geo.faces.push(new THREE.Face3(0, face + 1, face + 2));
+        geo.faces.push(new Face3(0, face + 1, face + 2));
       }
 
 
@@ -139,5 +145,4 @@ class ARPlanes extends THREE.Object3D {
   }
 }
 
-THREE.ARPlanes = ARPlanes;
 export default ARPlanes;

--- a/src/ARReticle.js
+++ b/src/ARReticle.js
@@ -13,13 +13,17 @@
  * limitations under the License.
  */
 
+import {
+  Mesh, RingGeometry, MeshBasicMaterial, Matrix4, Math as Math3, Vector3,
+} from 'three';
+
 import { placeObjectAtHit } from './ARUtils';
 
 /**
  * Class for creating a mesh that fires raycasts and lerps
  * a 3D object along the surface
  */
-class ARReticle extends THREE.Mesh {
+class ARReticle extends Mesh {
   /**
    * @param {VRDisplay} vrDisplay
    * @param {number} innerRadius
@@ -34,11 +38,11 @@ class ARReticle extends THREE.Mesh {
     color = 0xff0077,
     easing = 0.25
   ) {
-    const geometry = new THREE.RingGeometry(innerRadius, outerRadius, 36, 64);
-    const material = new THREE.MeshBasicMaterial({ color });
+    const geometry = new RingGeometry(innerRadius, outerRadius, 36, 64);
+    const material = new MeshBasicMaterial({ color });
 
     // Orient the geometry so it's position is flat on a horizontal surface
-    geometry.applyMatrix(new THREE.Matrix4().makeRotationX(THREE.Math.degToRad(-90)));
+    geometry.applyMatrix(new Matrix4().makeRotationX(Math3.degToRad(-90)));
 
     super(geometry, material);
     this.visible = false;
@@ -46,7 +50,7 @@ class ARReticle extends THREE.Mesh {
     this.easing = easing;
     this.applyOrientation = true;
     this.vrDisplay = vrDisplay;
-    this._planeDir = new THREE.Vector3();
+    this._planeDir = new Vector3();
   }
 
   /**
@@ -69,5 +73,4 @@ class ARReticle extends THREE.Mesh {
   }
 }
 
-THREE.ARReticle = ARReticle;
 export default ARReticle;

--- a/src/ARUtils.js
+++ b/src/ARUtils.js
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { Color, Matrix4, Quaternion, Vector3, Math as Math3 } from 'three';
+
 import { loadMtl, loadObj } from './loaders';
 
 const colors = [
@@ -31,25 +33,26 @@ const colors = [
   '#FFEB3B',
   '#FFC107',
   '#FF9800',
-].map(hex => new THREE.Color(hex));
+].map(hex => new Color(hex));
 
 const LEARN_MORE_LINK = 'https://developers.google.com/ar/develop/web/getting-started';
 const UNSUPPORTED_MESSAGE = `This augmented reality experience requires
   WebARonARCore or WebARonARKit, experimental browsers from Google
   for Android and iOS. Learn more at the <a href="${LEARN_MORE_LINK}">Google Developers site</a>.`;
 
-THREE.ARUtils = Object.create(null);
 
-THREE.ARUtils.isTango = display =>
+const ARUtils = Object.create(null);
+
+ARUtils.isTango = display =>
   display && display.displayName.toLowerCase().includes('tango');
-export const isTango = THREE.ARUtils.isTango;
+export const isTango = ARUtils.isTango;
 
-THREE.ARUtils.isARKit = display =>
+ARUtils.isARKit = display =>
   display && display.displayName.toLowerCase().includes('arkit');
-export const isARKit = THREE.ARUtils.isARKit;
+export const isARKit = ARUtils.isARKit;
 
-THREE.ARUtils.isARDisplay = display => isARKit(display) || isTango(display);
-export const isARDisplay = THREE.ARUtils.isARDisplay;
+ARUtils.isARDisplay = display => isARKit(display) || isTango(display);
+export const isARDisplay = ARUtils.isARDisplay;
 
 /**
  * Returns a promise that resolves to either to a VRDisplay with
@@ -57,7 +60,7 @@ export const isARDisplay = THREE.ARUtils.isARDisplay;
  *
  * @return {Promise<VRDisplay?>}
  */
-THREE.ARUtils.getARDisplay = () => new Promise((resolve, reject) => {
+ARUtils.getARDisplay = () => new Promise((resolve, reject) => {
   if (!navigator.getVRDisplays) {
     resolve(null);
     return;
@@ -78,7 +81,7 @@ THREE.ARUtils.getARDisplay = () => new Promise((resolve, reject) => {
     resolve(null);
   });
 });
-export const getARDisplay = THREE.ARUtils.getARDisplay;
+export const getARDisplay = ARUtils.getARDisplay;
 
 /**
  * Takes a path for an OBJ model and optionally a path for an MTL
@@ -89,7 +92,7 @@ export const getARDisplay = THREE.ARUtils.getARDisplay;
  * @param {string} mtlPath
  * @return {THREE.Mesh}
  */
-THREE.ARUtils.loadBlocksModel = (objPath, mtlPath) => new Promise((resolve, reject) => {
+ARUtils.loadBlocksModel = (objPath, mtlPath) => new Promise((resolve, reject) => {
   if (!THREE.OBJLoader || !THREE.MTLLoader) {
     reject(new Error('Must include THREE.OBJLoader and THREE.MTLLoader'));
     return;
@@ -109,18 +112,18 @@ THREE.ARUtils.loadBlocksModel = (objPath, mtlPath) => new Promise((resolve, reje
   }).then(obj => {
     const model = obj.children[0];
     model.geometry.applyMatrix(
-      new THREE.Matrix4().makeRotationY(THREE.Math.degToRad(-90))
+      new Matrix4().makeRotationY(Math3.degToRad(-90))
     );
 
     return model;
   }).then(resolve, reject);
 });
-export const loadBlocksModel = THREE.ARUtils.loadBlocksModel;
+export const loadBlocksModel = ARUtils.loadBlocksModel;
 
-const model = new THREE.Matrix4();
-const tempPos = new THREE.Vector3();
-const tempQuat = new THREE.Quaternion();
-const tempScale = new THREE.Vector3();
+const model = new Matrix4();
+const tempPos = new Vector3();
+const tempQuat = new Quaternion();
+const tempScale = new Vector3();
 
 /**
  * Takes a THREE.Object3D and a VRHit and positions and optionally orients
@@ -134,7 +137,7 @@ const tempScale = new THREE.Vector3();
  * @param {number} easing
  * @param {boolean} applyOrientation
  */
-THREE.ARUtils.placeObjectAtHit = (object, hit, easing=1, applyOrientation=false) => {
+ARUtils.placeObjectAtHit = (object, hit, easing=1, applyOrientation=false) => {
   if (!hit || !hit.modelMatrix) {
     throw new Error('placeObjectAtHit requires a VRHit object');
   }
@@ -155,22 +158,22 @@ THREE.ARUtils.placeObjectAtHit = (object, hit, easing=1, applyOrientation=false)
     }
   }
 };
-export const placeObjectAtHit = THREE.ARUtils.placeObjectAtHit;
+export const placeObjectAtHit = ARUtils.placeObjectAtHit;
 
 /**
  * Returns a random color from the stored palette.
  * @return {THREE.Color}
  */
-THREE.ARUtils.getRandomPaletteColor = () => {
+ARUtils.getRandomPaletteColor = () => {
   return colors[Math.floor(Math.random() * colors.length)];
 };
-export const getRandomPaletteColor = THREE.ARUtils.getRandomPaletteColor;
+export const getRandomPaletteColor = ARUtils.getRandomPaletteColor;
 
 /**
  * Injects a DOM element into the current page prompting the user that
  * their browser does not support these AR features.
  */
-THREE.ARUtils.displayUnsupportedMessage = () => {
+ARUtils.displayUnsupportedMessage = () => {
   const element = document.createElement('div');
   element.id = 'webgl-error-message';
   element.style.fontFamily = 'monospace';
@@ -186,4 +189,6 @@ THREE.ARUtils.displayUnsupportedMessage = () => {
   element.innerHTML = UNSUPPORTED_MESSAGE;
   document.body.appendChild(element);
 };
-export const displayUnsupportedMessage = THREE.ARUtils.displayUnsupportedMessage;
+export const displayUnsupportedMessage = ARUtils.displayUnsupportedMessage;
+
+export default ARUtils;

--- a/src/ARView.js
+++ b/src/ARView.js
@@ -387,5 +387,4 @@ class ARView {
   }
 }
 
-THREE.ARView = ARView;
 export default ARView;

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,29 @@
  */
 
 /* eslint no-unused-vars: "off" */
+/* eslint no-undef: "off" */
 import ARDebug from './ARDebug';
 import ARPerspectiveCamera from './ARPerspectiveCamera';
 import ARReticle from './ARReticle';
 import ARUtils from './ARUtils';
 import ARView from './ARView';
 import './ARSpeechRecognition';
+
+// If including three.ar.js as a standalone script tag,
+// we'll need to expose these objects directly by attaching
+// them on the THREE global
+if (typeof global.THREE === 'object') {
+  global.THREE.ARDebug = ARDebug;
+  global.THREE.ARPerspectiveCamera = ARPerspectiveCamera;
+  global.THREE.ARReticle = ARReticle;
+  global.THREE.ARUtils = ARUtils;
+  global.THREE.ARView = ARView;
+}
+
+export {
+  ARDebug,
+  ARPerspectiveCamera,
+  ARReticle,
+  ARUtils,
+  ARView,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
     "three.ar.min": "./src/index.js"
   },
   output: {
+    libraryTarget: 'umd',
     path: path.join(__dirname, "dist"),
     filename: "[name].js"
   },
@@ -43,6 +44,14 @@ module.exports = {
         use: ["base64-image-loader"],
       },
     ]
+  },
+  externals: {
+    three: {
+      commonjs: 'three',
+      commonjs2: 'three',
+      amd: 'three',
+      root: 'THREE',
+    },
   },
   resolve: {
     extensions: [".js"]
@@ -64,8 +73,8 @@ module.exports = {
     // https://github.com/webpack/webpack-dev-server/issues/1101
     // https://github.com/webpack/webpack-dev-server/tree/ee7231baf9f41082435832e6df3e57f4dafee013#caveats
     new UglifyJSPlugin({
-    // new webpack.optimizeUglifyJsPlugin({
-      include: /\.min\.js$/
+      // The unbundled plugin also needs 'test' instead of 'include' (?),
+      test: /\.min\.js$/
     }),
     new webpack.BannerPlugin({ banner: license, raw: true }),
   ]


### PR DESCRIPTION
Configure webpack to continue using THREE globals in script environment, but use three.js as a peer dependency in modular environments.