### PR TITLE
Transparency flicker fix

### DIFF
--- a/examples/boilerplate.html
+++ b/examples/boilerplate.html
@@ -142,6 +142,9 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();

--- a/examples/graffiti.html
+++ b/examples/graffiti.html
@@ -594,6 +594,9 @@ function updatePhysics()
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();

--- a/examples/record-at-camera.html
+++ b/examples/record-at-camera.html
@@ -17,7 +17,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>three.ar.js - Spawn At Camera</title>
+  <title>three.ar.js - Record At Camera</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no,
   minimum-scale=1.0, maximum-scale=1.0">

--- a/examples/reticle.html
+++ b/examples/reticle.html
@@ -152,6 +152,9 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+  
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();

--- a/examples/spawn-at-camera.html
+++ b/examples/spawn-at-camera.html
@@ -178,6 +178,9 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+  
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();

--- a/examples/spawn-at-surface.html
+++ b/examples/spawn-at-surface.html
@@ -189,6 +189,9 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+  
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();

--- a/examples/surfaces.html
+++ b/examples/surfaces.html
@@ -141,6 +141,9 @@ function init() {
  * our scene and rendering.
  */
 function update() {
+  // Clears color from the frame before rendering the camera (arView) or scene.
+  renderer.clearColor();
+
   // Render the device's camera stream on screen first of all.
   // It allows to get the right pose synchronized with the right frame.
   arView.render();


### PR DESCRIPTION
Bug fix for flickering transparency on rendered objects in the scenes on iOS. Resolved by clearing the color on the frame at the beginning of the update. Change propagated onto all examples in the repo.