### PR TITLE
fixes bug in mtl loading pipeline

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -32,11 +32,8 @@ export const loadObj = (objPath, materials) => new Promise((resolve, reject) => 
 
 export const loadMtl = mtlPath => new Promise((resolve, reject) => {
   const loader = new global.THREE.MTLLoader();
-  const pathChunks = mtlPath.split('/');
 
-  if (pathChunks.length >= 2) {
-    loader.setTexturePath(pathChunks[pathChunks.length - 2]);
-  }
+  loader.setTexturePath(mtlPath.substring(0, mtlPath.lastIndexOf("/") + 1));
 
   loader.load(mtlPath, resolve, noop, reject);
 });

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -33,7 +33,7 @@ export const loadObj = (objPath, materials) => new Promise((resolve, reject) => 
 export const loadMtl = mtlPath => new Promise((resolve, reject) => {
   const loader = new global.THREE.MTLLoader();
 
-  loader.setTexturePath(mtlPath.substring(0, mtlPath.lastIndexOf("/") + 1));
+  loader.setTexturePath(mtlPath.substring(0, mtlPath.lastIndexOf('/') + 1));
 
   loader.load(mtlPath, resolve, noop, reject);
 });


### PR DESCRIPTION
material paths were missing the trailing "/" and didn't support materials that were greater than 1 directory away. this solution should work for paths of any distance.