### PR TITLE
fix A-Frame text causing mirrored camera view on iOS 11.3

### DIFF
--- a/src/ARView.js
+++ b/src/ARView.js
@@ -257,6 +257,7 @@ class ARVideoRenderer {
       gl.ARRAY_BUFFER_BINDING,
       gl.ELEMENT_ARRAY_BUFFER_BINDING,
       gl.CURRENT_PROGRAM,
+      gl.TEXTURE_BINDING_2D,
     ];
 
     preserveGLState(gl, bindings, () => {
@@ -265,6 +266,13 @@ class ARVideoRenderer {
           this.passThroughCamera.textureHeight === 0) {
         return;
       }
+
+      // Save and configure values we need.
+      let previousFlipY = gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL);
+      let previousWinding = gl.getParameter(gl.FRONT_FACE);
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+      gl.frontFace(gl.CCW);
+
       gl.useProgram(this.program);
       gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexPositionBuffer);
       gl.enableVertexAttribArray(this.vertexPositionAttribute);
@@ -334,6 +342,10 @@ class ARVideoRenderer {
         gl.UNSIGNED_SHORT,
         0
       );
+
+      // Restore previous values.
+      gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, previousFlipY);
+      gl.frontFace(previousWinding);
     });
   }
 }


### PR DESCRIPTION
##### Changes Proposed:
save and configure extra values we need, then restore when we're done,
so that using A-Frame text doesn't mirror camera view on iOS 11.3

##### Fixes:
save and restore flipY and frontFace
also, TEXTURE_BINDING_2D

##### Checklist:

- [x] Tested on WebARonARCore
- [x] Tested on WebARonARKit
- [x] I've read CONTRIBUTING.md and signed the CLA (required)
- [x] This PR does not contain built changes in `dist/\*` (required)
- [x] This PR only contains one commit (required)
